### PR TITLE
App Websocket Crashes When Publish Called

### DIFF
--- a/src/nanoexpress.js
+++ b/src/nanoexpress.js
@@ -334,7 +334,7 @@ const nanoexpress = (options = {}) => {
     };
   });
 
-  _app.publish = app.publish;
+  _app.publish = (channel, message) => app.publish(channel, message);
 
   return _app;
 };


### PR DESCRIPTION
- updates app publish assignment to passthrough to the local prop

*Issue*

After initializing the websockets section of the nanoexpress app, calling the ``` app.publish(channel, message) ``` method would cause the server to silently crash.