### PR TITLE
feat: pass websocket to close event

### DIFF
--- a/examples/websocket.js
+++ b/examples/websocket.js
@@ -17,7 +17,7 @@ app.ws('/ws', async (req, res) => {
       console.log('Message received', msg);
       ws.send(msg);
     });
-    ws.on('close', (code, message) => {
+    ws.on('close', (closedWs, code, message) => {
       // eslint-disable-next-line security-node/detect-crlf
       console.log('Connection closed', { code, message });
     });

--- a/nanoexpress.d.ts
+++ b/nanoexpress.d.ts
@@ -49,7 +49,7 @@ declare namespace nanoexpress {
       listener: (req: HttpRequest, res: HttpResponse) => void
     ): void;
     on(event: 'drain', listener: (drain_amount: number) => void): void;
-    on(event: 'close', listener: (code: number, message: string) => void): void;
+    on(event: 'close', listener: (ws: WebSocket, code: number, message: string) => void): void;
     on(
       event: 'message',
       listener: (message: string | any, isBinary?: boolean) => void

--- a/src/Route.js
+++ b/src/Route.js
@@ -577,7 +577,7 @@ export default class Route {
           ws.emit('drain', ws.getBufferedAmount());
         },
         close: (ws, code, message) => {
-          ws.emit('close', code, Buffer.from(message).toString('utf8'));
+          ws.emit('close', ws, code, Buffer.from(message).toString('utf8'));
         }
       };
     }


### PR DESCRIPTION
* useful for checking which client closed the connection. Especially when keeping track of pub/sub.
* refs: https://unetworking.github.io/uWebSockets.js/generated/interfaces/websocketbehavior.html#close

## Pull Request

### Is you/your team sponsoring this project

- [ ] Yes
- [x] No

#### _If your team sponsoring this project, please attach here your team lead or who purchased license GitHub login_

### What you changed

- [x] Code changes
- [ ] Tests changed
- [ ] Typo fixes

#### _If you change code, tests should be passed_

### Note

- **Your every change to feature/code should be documented**
- **📝 Documentation** fixes should be filled [here](https://github.com/nanoexpress/docs/pulls)
- **🔗 Middlewares** fixes should be filled [here](https://github.com/nanoexpress/middlewares/pulls)
