### PR TITLE
fix: fix typo in setCookie function

### DIFF
--- a/src/response-proto/http/cookie-chunks/set-cookie.js
+++ b/src/response-proto/http/cookie-chunks/set-cookie.js
@@ -8,7 +8,7 @@ export default function setCookie(name, value, options) {
 
   let getCookie = this.getHeader('Set-Cookie');
 
-  if (!setCookie) {
+  if (!getCookie) {
     this.setHeader('Set-Cookie', serialized);
     return undefined;
   }


### PR DESCRIPTION
## Pull Request

### Is you/your team sponsoring this project

- [ ] Yes
- [x] No

#### _If your team sponsoring this project, please attach here your team lead or who purchased license GitHub login_

### What you changed

- [x] Code changes
- [ ] Tests changed
- [x] Typo fixes


#### _If you change code, tests should be passed_

### Note

- **Your every change to feature/code should be documented**
- **📝 Documentation** fixes should be filled [here](https://github.com/nanoexpress/docs/pulls)
- **🔗 Middlewares** fixes should be filled [here](https://github.com/nanoexpress/middlewares/pulls)
- 
I call the res.setCookie function as follows:

```
res.setCookie('authToken', token, {
            expires: expireInOne,
            domain: 'localhost',
            path: '/',
            isSecure: false,
            httpOnly: true,
            sameSite: false,
          })
```
and receive the following error:
```
TypeError: Cannot read property 'push' of undefined
    at uWS.HttpResponse.setCookie (/Users/cryptodeal/Desktop/PWA/backend/node_modules/.pnpm/nanoexpress@2.4.8/node_modules/nanoexpress/cjs/nanoexpress.js:507:13)
```

Typo in the setCookie function, which the PR fixes, was the cause of the bug.

