### PR TITLE
fix(route): Make fastQueryParse always have String

### DIFF
--- a/src/Route.js
+++ b/src/Route.js
@@ -428,7 +428,7 @@ export default class Route {
                 req.params = params(req, preparedParams);
               }
               if (!_schema || _schema.query !== false) {
-                req.query = fastQueryParse(req.getQuery());
+                req.query = fastQueryParse(req.getQuery() || '');
               }
               if (
                 req.headers &&


### PR DESCRIPTION
fix: Found a bug where req.getQuery() returns undefined and sends it to fastQueryParse.

### Is you/your team sponsoring this project

- [ ] Yes
- [x] No

### What you changed

- [x] Code changes
- [ ] Tests changed
- [ ] Typo fixes

I've been getting this error after upgrading `nanoexpress` to `v6.2.0`:

```
/home/izelnakri/Github/qunitx/node_modules/fast-query-parse/parse.js:20
  if (str.indexOf('%') !== -1) {
          ^

TypeError: Cannot read properties of undefined (reading 'indexOf')
    at parse (/home/izelnakri/Github/qunitx/node_modules/fast-query-parse/parse.js:20:11)
    at handler (file:///home/izelnakri/Github/qunitx/node_modules/nanoexpress/src/Route.js:431:29)
```

on a request that is on the root of a web server: `http://localhost:1234/` (it ends with `/` but many paths resulted in this error actually, strange that test suite passed for nanoexpress after the `v6.2.0` changes)